### PR TITLE
Set torch to off onDestroy(), fixes #2

### DIFF
--- a/mTorch/src/main/java/com/wkovacs64/mtorch/mTorchService.java
+++ b/mTorch/src/main/java/com/wkovacs64/mtorch/mTorchService.java
@@ -184,6 +184,10 @@ public class mTorchService extends Service implements SurfaceHolder.Callback {
         Log.d(TAG, "********** onDestroy **********");
         super.onDestroy();
 
+        // Set torch to off first, in the off case the activity/service is 
+        // restarted too quickly.
+        mIsTorchOn = false;
+        
         mIsRunning = false;
 
         // If this service was told to stop for some reason and persistence was enabled,


### PR DESCRIPTION
In the off case the application is restarted to quickly, it hasn't destroyed the surface yet.  Setting torch to off onDestroy() allows mIsTorchOn to return false when starting back up, thus allowing autoOn to turn it back on, instead of turning it off.
